### PR TITLE
check brew output in stderr

### DIFF
--- a/src/brew.py
+++ b/src/brew.py
@@ -55,7 +55,7 @@ def get_open_link_command(formula):
 def brew_not_installed():
     _, err = subprocess.Popen(
         ['command', '/usr/local/bin/brew'], stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
-    return err != ''
+    return err != '' and not 'Example usage:' in err
 
 
 def get_icon(name):


### PR DESCRIPTION
In some cases check brew installed in brew_not_installed() output help message in stderr

python and brew versions:
```sh
# python -V && brew -v
Python 2.7.11
Homebrew 0.9.5 (git revision 29f73d; last commit 2016-02-09)
```