### PR TITLE
fixes command for upgrading and outdated brew

### DIFF
--- a/src/brew.py
+++ b/src/brew.py
@@ -190,7 +190,7 @@ def main(wf):
             for formula in filter_outdated_formulae(wf, query):
                 name = formula.rsplit()[0]
                 wf.add_item(formula, 'Update formula.',
-                            arg='upgrade %s' % name,
+                            arg='brew upgrade %s' % name,
                             valid=True,
                             icon=helpers.get_icon(wf, 'package'))
         elif query and query.startswith('info'):


### PR DESCRIPTION
without the command I am getting `-bash: upgrade: command not found`