### PR TITLE
Removed support for deprecated --caskroom option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you installed Homebrew Cask and changed where the applications are installed 
 
 ```shell
 # Specify your defaults in this environment variable
-export HOMEBREW_CASK_OPTS="--appdir=/Applications --caskroom=/usr/local/Caskroom"
+export HOMEBREW_CASK_OPTS="--appdir=/Applications"
 ```
 
 You need to update workflow's settings accordingly to your configuration.

--- a/src/cask.py
+++ b/src/cask.py
@@ -16,7 +16,6 @@ OPEN_HELP = 'open https://github.com/fniephaus/alfred-homebrew && exit'
 DEFAULT_SETTINGS = {
     'HOMEBREW_CASK_OPTS': {
         'appdir': '/Applications',
-        'caskroom': '/usr/local/Caskroom'
     }
 }
 
@@ -28,9 +27,8 @@ def execute(wf, command):
     opts = wf.settings.get('HOMEBREW_CASK_OPTS', None)
     cmd_list = ['brew', 'cask', command]
     if opts:
-        if all(k in opts for k in ('appdir', 'caskroom')):
-            cmd_list += ['--appdir=%s' % opts['appdir'],
-                         '--caskroom=%s' % opts['caskroom']]
+        if all(k in opts for k in ('appdir')):
+            cmd_list += ['--appdir=%s' % opts['appdir']]
 
     new_env = os.environ.copy()
     new_env['PATH'] = '/usr/local/bin:%s' % new_env['PATH']


### PR DESCRIPTION
I don't know if there is other Cask stuff that should be updated, as I haven't been using it for that long, but this at least fixes the workflow.

Fixes #26