### PR TITLE
Update cask.py

### DIFF
--- a/src/cask.py
+++ b/src/cask.py
@@ -35,9 +35,6 @@ def execute(wf, cmd_list):
     if err:
         return 'Error: %s' % err
 
-    if 'sudo' in result:
-        return 'Config'
-
     return result
 
 


### PR DESCRIPTION
Through testing of 200+ Cask packages on a fresh install of MacOS and home-brew, this check was never triggered nor appears to be required.

Recommend removing this code