### PR TITLE
Move version to plist

### DIFF
--- a/src/info.plist
+++ b/src/info.plist
@@ -147,6 +147,8 @@
 			<real>10</real>
 		</dict>
 	</dict>
+	<key>version</key>
+	<string>5.0</string>
 	<key>webaddress</key>
 	<string>https://github.com/fniephaus/alfred-homebrew/</string>
 </dict>


### PR DESCRIPTION
Best practice is for version to exist in info.plist, so that it is visible to end-user. There is currently no way to tell what version an installed workflow is; if it is current or out of date.